### PR TITLE
Fix ci

### DIFF
--- a/.ci/test.py
+++ b/.ci/test.py
@@ -56,6 +56,10 @@ def enumerate_plugins(basedir: Path) -> Generator[Plugin, None, None]:
     ]
     print(poetry_pytest)
 
+    rust_pytest = [
+        x for x in plugins if (x / Path("Cargo.toml")).exists()
+    ]
+
     for p in sorted(pip_pytest):
         yield Plugin(
             name=p.name,
@@ -79,6 +83,17 @@ def enumerate_plugins(basedir: Path) -> Generator[Plugin, None, None]:
             }
         )
 
+    for p in sorted(rust_pytest):
+        yield Plugin(
+            name=p.name,
+            path=p,
+            language="rust",
+            framework="cargo",
+            details={
+                "cargo": p / Path("Cargo.toml"),
+            }
+        )
+
 def prepare_env(p: Plugin, directory: Path) -> bool:
     """ Returns whether we can run at all. Raises error if preparing failed.
     """
@@ -91,6 +106,8 @@ def prepare_env(p: Plugin, directory: Path) -> bool:
         return prepare_env_pip(p, directory)
     elif p.framework == "poetry":
         return prepare_env_poetry(p, directory)
+    elif p.framework == "cargo":
+        return prepare_env_cargo(p, directory)
     else:
         raise ValueError(f"Unknown framework {p.framework}")
 
@@ -159,6 +176,21 @@ def prepare_env_pip(p: Plugin, directory: Path):
             [pip_path, 'install', '-U', *pip_opts, '-r', p.details['devrequirements']],
             stderr=subprocess.STDOUT,
         )
+    install_pyln_testing(pip_path)
+    return True
+
+
+def prepare_env_cargo(p: Plugin, directory: Path):
+    pip_path = directory / 'bin' / 'pip3'
+
+    # Install pytest (eventually we'd want plugin authors to include
+    # it in their requirements-dev.txt, but for now let's help them a
+    # bit).
+    subprocess.check_call(
+        [pip_path, 'install', *pip_opts, *global_dependencies],
+        stderr=subprocess.STDOUT,
+    )
+
     install_pyln_testing(pip_path)
     return True
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
 
     - name: Checkout c-lightning@v23.11
       uses: actions/checkout@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,3 @@
 [submodule "python-teos"]
 	path = python-teos
 	url = https://github.com/talaia-labs/python-teos
-[submodule "nostrify"]
-	path = nostrify
-	url = https://github.com/joelklabo/nostrify

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Community curated plugins for Core-Lightning.
 | [listmempoolfunds][listmempoolfunds] | Track unconfirmed wallet deposits                                                           |
 | [monitor][monitor]                   | helps you analyze the health of your peers and channels                                     |
 | [noise][noise]                       | Chat with your fellow node operators                                                        |
-| [nostrify][nostrify]                 | Send CLN events to Nostr                                                                    |
 | [paythrough][paythrough]             | Pay an invoice through a specific channel, regardless of better routes                      |
 | [persistent-channels][pers-chans]    | Maintains a number of channels to peers                                                     |
 | [poncho][poncho]                     | Turns CLN into a [hosted channels][blip12] provider                                         |
@@ -205,7 +204,6 @@ Python plugins developers must ensure their plugin to work with all Python versi
 [js-api]: https://github.com/lightningd/clightningjs
 [ts-api]: https://github.com/runcitadel/c-lightning.ts
 [monitor]: https://github.com/renepickhardt/plugins/tree/master/monitor
-[nostrify]: https://github.com/joelklabo/nostrify
 [reckless]: https://github.com/darosior/reckless
 [request-invoice]: https://github.com/lightningd/plugins/tree/master/request-invoice
 [sauron]: https://github.com/lightningd/plugins/tree/master/sauron


### PR DESCRIPTION
Hi, in the process of adding one of my plugins, that is written in rust, into the ci of the plugins repo i found out how to make the ci look into submodules. It found one more python plugin with tests: nostrify. According to the README of nostrify it is no longer maintained and the tests are failing.
I also added a commit to detect rust plugins and provide the pyln-testing dependencies. Rust plugins need to have some way to get the binary for the ci in their test files (which holdinvoice now does).
See my tests pass here:
https://github.com/daywalker90/plugins/actions/runs/7762270434/job/21172388533#step:7:254